### PR TITLE
FIX: resolving the dependencies for SocketIoEventLoader

### DIFF
--- a/lib/socket-io-client.module.ts
+++ b/lib/socket-io-client.module.ts
@@ -34,7 +34,7 @@ export class SocketIoClientModule {
         },
         SocketIoEventLoader,
       ],
-      exports: [],
+      exports: [SOCKET_IO_CLIENT],
     };
   }
 }


### PR DESCRIPTION
Looks like you missing the export of SOCKET_IO_CLIENT injector, this won't allow you to use it properly and will fix #1 

I really hope you continue working on this repository, since there's no client yet for NestJs socket io. Thank you!
